### PR TITLE
reducing and clarifying deps, cleanup of coffee

### DIFF
--- a/lib/httpster.coffee
+++ b/lib/httpster.coffee
@@ -1,47 +1,39 @@
 #!/usr/bin/env node
 
-/*
+###
   HTTPster
   Copyright(c) 2010 Simeon Bateman <simeon@simb.net>
   MIT Licensed
-*/
+###
 
-var fs = require('fs')
-  , program = require('commander')
-  , exec = require('child_process').exec
-  , express = require('express')
-  , port = 3333
-  , path = "./"
+fs = require('fs')
+program = require('commander')
+exec = require('child_process').exec
+connect = require('connect')
+path = "./"
+port = undefined
 
 program
   .version('0.1.0')
   .option('-p, --port <port>', 'Port for server to run on - defaults to 3333')
   .option('-d, --dir [path]', 'Server directory - defaults to ./')
-  .parse(process.argv);
+  .parse(process.argv)
 
-if (program.port) port = program.port;
-if (program.dir){
-  path = program.dir;
-}else{
-  path = fs.realpathSync(path);
-}
+port = program.port ? 3333
+path = program.dir ? fs.realpathSync(path)
 
-startDefaultServer = function(port, path) {
-  var server;
-  server = express();
-  server.configure(function() {
-    server.use(express.static(path));
-    server.use(express.errorHandler({ dumpExceptions: true, showStack: true }));
-    server.use(express.logger(':method :url :status'));
-    
-  });
-  server.get('/', function(req, res) {
-    return res.render('index.html');
-  });
-  server.listen(parseInt(port, 10));
-  
-  return server;
-};
+startDefaultServer = (port, path) ->
 
-console.log("Starting Server on port %j from %s", port, path);
-startDefaultServer(port, path);
+  app = connect()
+
+  app.use connect.static(path)
+  app.use connect.logger(format:"dev")
+  app.use connect.errorHandler(dumpExceptions: true, showStack: true)
+
+  #app.use '/', (req, res) ->  res.render('index.html')
+  app.listen(parseInt(port, 10))
+
+  app
+
+console.log("Starting Server on port %j from %s", port, path)
+startDefaultServer(port, path)

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   , "preferGlobal": "true"
   , "scripts" : { "prepublish" : "npm prune", "test": "make test" }
   , "dependencies": {
-      "express": "*",
-      "commander": "*"
+      "connect": "2.7.0",
+      "commander": "1.1.1"
   }
   , "devDependencies": {
       "should": "*"


### PR DESCRIPTION
- the lib file was specified `.coffee` but was `.js`. switched it back to coffee and cleaned the code - you can convert back to js if need be
- replaced express with connect (no need for extra deps)
- specified versions in `package.json`, prevents all the deprecated issues
- added dev logging output
