### PR TITLE
use node to make sure coffee command works on all platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   , "bin": { "httpster": "./bin/httpster" }
   , "preferGlobal": "true"
   , "scripts" : { 
-      "postinstall": "./node_modules/coffee-script/bin/coffee -o lib/ src/",
+      "postinstall": "node ./node_modules/coffee-script/bin/coffee -o lib/ src/",
       "test": "make test" }
   , "dependencies": {
       "connect": "2.7.0",


### PR DESCRIPTION
on install on windows I get 

httpster@0.3.1 postinstall C:\Users\Scott\AppData\Roaming\npm\node_modules\httpster
./node_modules/coffee-script/bin/coffee -o lib/ src/
'.' is not recognized as an internal or external command,
operable program or batch file.
npm ERR! httpster@0.3.1 postinstall: ./node_modules/coffee-script/bin/coffee -o lib/ src/
npm ERR! cmd "/c" "./node_modules/coffee-script/bin/coffee -o lib/ src/" failed with 1
npm ERR!
npm ERR! Failed at the httpster@0.3.1 postinstall script.

Made a small fix to address this
