### PR TITLE
Adds MIT license to project

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "author": "Simeon Bateman <simeon@simb.net> (http://www.simb.net)",
   "name": "httpster",
+  "license": "MIT",
   "description": "Simple http server for static content",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "repository": "git://github.com/SimbCo/httpster.git",
   "keywords": [
     "http",


### PR DESCRIPTION
Suggests adding a license to the project, which is a good idea and silences npm warnings. Suggesting MIT license as a suggestion. Bumps patch version number assuming https://github.com/SimbCo/httpster/pull/27 is accepted. 